### PR TITLE
Remove pip downloads cache

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -9,15 +9,6 @@ runs:
       with:
         python-version: 3.10.2
 
-    - name: "Cache pip downloads"
-      id: cache-pip-downloads
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: pip-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
-        restore-keys: |
-          pip-${{ runner.os }}-
-
     - name: "Install poetry"
       shell: bash
       run: pip install poetry==1.1.10  poetry-core==1.0.6


### PR DESCRIPTION
Causes issues with dependency upgrades when cache is not found